### PR TITLE
회원정보수정 리팩토링 작업

### DIFF
--- a/Member.php
+++ b/Member.php
@@ -7,7 +7,7 @@
  * @file /modules/member/Member.php
  * @author youlapark <youlapark@naddle.net>
  * @license MIT License
- * @modified 2024. 11. 8.
+ * @modified 2024. 11. 15.
  */
 namespace modules\member;
 class Member extends \Module
@@ -28,7 +28,6 @@ class Member extends \Module
     private static array $_levels;
 
     /**
-     *
      * @var ?int $_logged 로그인정보
      */
     private static ?int $_logged = null;

--- a/dtos/Member.php
+++ b/dtos/Member.php
@@ -5,9 +5,9 @@
  * 회원 구조체를 정의한다.
  *
  * @file /modules/member/dtos/Member.php
- * @author Arzz <arzz@arzz.com>
+ * @author youlapark <youlapark@naddle.net>
  * @license MIT License
- * @modified 2024. 10. 30.
+ * @modified 2024. 11. 14.
  */
 namespace modules\member\dtos;
 class Member
@@ -28,6 +28,11 @@ class Member
      * @var string $_email 이메일
      */
     private string $_email;
+
+    /**
+     * @var string $_password 패스워드
+     */
+    private string $_password;
 
     /**
      * @var ?string $_code 회원추가코드
@@ -105,6 +110,7 @@ class Member
             $this->_member = $member;
             $this->_id = intval($member->member_id);
             $this->_email = $member->email;
+            $this->_password = $member->password;
             $this->_name = $member->name;
             $this->_nickname = $member->nickname;
             $this->_telephone = $member->telephone;
@@ -134,6 +140,16 @@ class Member
     public function getEmail(): string
     {
         return $this->_email;
+    }
+
+    /**
+     * 패스워드를 가져온다.
+     *
+     * @return string $password
+     */
+    public function getPassword(): string
+    {
+        return $this->_password;
     }
 
     /**

--- a/processes/login.check.post.php
+++ b/processes/login.check.post.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * 이 파일은 아이모듈 회원모듈의 일부입니다. (https://www.imodules.io)
+ *
+ * 회원의 유효성을 확인한다.
+ *
+ * @file /modules/member/processes/login.check.post.php
+ * @author youlapark <youlapark@naddle.net>
+ * @license MIT License
+ * @modified 2024. 11. 15.
+ *
+ * @var \modules\member\Member $me
+ */
+if (defined('__IM_PROCESS__') == false) {
+    exit();
+}
+
+/**
+ * 관리자권한이 존재하는지 확인한다.
+ */
+if ($me->getAdmin()->checkPermission('members', ['edit']) == false) {
+    $results->success = false;
+    $results->message = $me->getErrorText('FORBIDDEN');
+    return;
+}
+
+if ($me->isLogged() == false) {
+    $results->success = false;
+    $results->message = $me->getErrorText('REQUIRED_LOGIN');
+} else {
+    $errors = [];
+    $password = Input::get('password', $errors);
+
+    if (count($errors) == 0) {
+        $member = $me->getMember($me->getLogged());
+        $email = $member->getEmail();
+        $origin_password = $member->getPassword();
+
+        $verify = Password::verify($password, $origin_password);
+
+        if ($verify) {
+            $results->success = true;
+        } else {
+            $results->success = false;
+            $results->message = $me->getErrorText('INVALID_PASSWORD');
+        }
+    } else {
+        $results->success = false;
+        $results->message = $me->getErrorText('INVALID_PASSWORD');
+    }
+}

--- a/processes/password.post.php
+++ b/processes/password.post.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * 이 파일은 아이모듈 회원모듈의 일부입니다. (https://www.imodules.io)
+ *
+ * 패스워드를 변경한다.
+ *
+ * @file /modules/member/processes/password.post.php
+ * @author youlapark <youlapark@naddle.net>
+ * @license MIT License
+ * @modified 2024. 11. 15.
+ *
+ * @var \modules\member\Member $me
+ */
+if (defined('__IM_PROCESS__') == false) {
+    exit();
+}
+
+/**
+ * 관리자권한이 존재하는지 확인한다.
+ */
+if ($me->getAdmin()->checkPermission('members', ['edit']) == false) {
+    $results->success = false;
+    $results->message = $me->getErrorText('FORBIDDEN');
+    return;
+}
+
+if ($me->isLogged() == false) {
+    $results->success = false;
+    $results->message = $me->getErrorText('REQUIRED_LOGIN');
+}
+
+$errors = [];
+$password = Input::get('password', $errors);
+
+if (count($errors) == 0) {
+    $member_id = $me->getLogged();
+
+    $insert['password'] = \Password::hash($password);
+
+    $results = $me
+        ->db()
+        ->update($me->table('members'), $insert)
+        ->where('member_id', $member_id)
+        ->execute();
+
+    if ($results == true) {
+        $results->success = true;
+    } else {
+        $results->success = false;
+        $results->message = 'CONNECT_ERROR';
+    }
+} else {
+    $results->success = false;
+    $results->errors = 'REQUIRED';
+}

--- a/scripts/Member.ts
+++ b/scripts/Member.ts
@@ -6,7 +6,7 @@
  * @file /modules/member/scripts/Member.ts
  * @author youlapark <youlapark@naddle.net>
  * @license MIT License
- * @modified 2024. 11. 8.
+ * @modified 2024. 11. 15.
  */
 namespace modules {
     export namespace member {
@@ -20,101 +20,14 @@ namespace modules {
              */
             init($dom: Dom): void {
                 const context = $dom.getData('context');
-
                 switch (context) {
                     case 'oauth.link':
                         this.initOAuthLink($dom);
                         break;
                     case 'edit':
-                        /**
-                         * @TODO section의 data-role에 따른 분기 처리
-                         * data-role="edit" - 회원 검증
-                         * data-role="edit" - 회원 정보 수정
-                         */
-                        const $view = Html.get('section').getAttr('data-role');
-
-                        const $profile = Html.get('section[data-role="profile"]');
-                        const member_id = $profile.getAttr('data-user-id');
-
-                        switch ($view) {
-                            case 'edit':
-                                this.showEdit();
-                                break;
-
-                            case 'profile':
-                                this.showProfile(member_id);
-                                this.showPassword(member_id);
-                                break;
-                        }
+                        this.showAuthCheck($dom);
                 }
-
                 super.init($dom);
-            }
-
-            /**
-             * 로그인한 회원이 맞는지 검증을 한다.
-             */
-            async showEdit() {
-                const $form = Html.get('form', this.$dom);
-                const form = Form.get($form);
-
-                Html.get('input', $form).on('input', () => {
-                    const $message = Html.get('div[data-role=message]', $form);
-                    $message.remove();
-                });
-
-                form.onSubmit(async () => {
-                    const results = await form.submit(iModules.getProcessUrl('module', 'admin', 'login'));
-
-                    if (results.success == true) {
-                        // @TODO 로그인한 회원의 비밀번호 검증이 끝나면, 정보수정 페이지 로드하기.
-                        iModules.Modal.show('로그인성공', '로그인 성공. 이제 정보수정하러가자', [
-                            {
-                                text: '닫기',
-                                class: 'confirm',
-                                handler: () => {
-                                    iModules.Modal.close();
-                                },
-                            },
-                        ]);
-                    } else {
-                        if (results.message) {
-                            const $message = Html.create('div', { 'data-role': 'message' });
-                            $message.html(results.message);
-                            $form.append($message);
-                        }
-                        $form.shake();
-                    }
-                });
-            }
-
-            /**
-             * 기본정보수정 페이지를 호출한다.
-             *
-             * @param {string} member_id - 접속한 회원의 멤버아이디
-             */
-            async getProfile(member_id: string): Promise<boolean> {
-                const results = await Ajax.get(this.getProcessUrl('member'), {
-                    member_id: member_id,
-                });
-                if (results.success == false) {
-                    iModules.Modal.show(
-                        '문제가 발생하였습니다.',
-                        (results.message ?? '요청을 처리하던 중 문제가 발생하였습니다.') +
-                            '<br>페이지를 새로고침하여 재시도해보시기 바랍니다.',
-                        [
-                            {
-                                text: '페이지 새로고침',
-                                class: 'confirm',
-                                handler: () => {
-                                    location.reload();
-                                },
-                            },
-                        ]
-                    );
-                    return false;
-                }
-                return true;
             }
 
             /**
@@ -134,11 +47,223 @@ namespace modules {
             }
 
             /**
-             * 프로필사진을 수정한다.
+             * 로그인한 회원이 맞는지 비밀번호를 통해 검증한다.
              *
-             * @param {string} member_id - 회원 고유번호
+             * @param {Dom} $dom - 모듈 DOM 객체
              */
-            async showProfile(member_id: string) {
+            async showAuthCheck($dom: Dom): Promise<void> {
+                const $form = Html.get('form', $dom);
+                const form = Form.get($form);
+
+                const $message = Html.get('div[data-role="message"]');
+
+                form.onSubmit(async () => {
+                    const results = await form.submit(this.getProcessUrl('login.check'));
+                    if (results.success == true) {
+                        const $edit = Html.get('section[data-role="edit"]');
+                        $edit.empty();
+                        this.showProfile();
+                    } else {
+                        $message.setStyle('padding', '10px 0px 5px 0px');
+                        $message.setStyle('font-size', '14px');
+                        $message.setStyle('color', 'var(--im-color-danger-600)');
+                        $message.html(results.message);
+                        $form.shake();
+                    }
+                });
+            }
+
+            /**
+             * 프로필을 수정하는 페이지를 호출한다.
+             */
+            async showProfile(): Promise<void> {
+                const $profile = Html.get('section[data-role="profile"]');
+                const member_id = $profile.getAttr('data-user-id');
+
+                const $container = Html.create('div', { 'data-role': 'container' });
+                const $update = Html.create('div', { 'data-role': 'update' });
+
+                const $h4 = Html.create('h4', null, '기본정보수정');
+                $update.append($h4);
+
+                const $form = Html.create('form');
+
+                const $ul = Html.create('ul', { 'data-role': 'form' });
+
+                const photo = $profile.getAttr('data-photo');
+                const $photo_li = Html.create('li', { 'data-role': 'photo' });
+                const $photo_ul = Html.create('ul');
+                const $photo_li_label = Html.create('li');
+                const $photo_b_label = Html.create('b', null, '회원사진');
+                $photo_li_label.append($photo_b_label);
+                const $photo_li_button = Html.create('li');
+                const $photo_button = Html.create('button', {
+                    type: 'button',
+                    'data-action': 'photo',
+                    style: `background-image:linear-gradient(to bottom,
+                            rgba(0, 0, 0, 0) 60%,
+                            rgba(0, 0, 0, 0.7) 100%),url("${photo}")`,
+                });
+                $photo_button.on('click', async () => {
+                    await this.updatePhoto();
+                });
+                $photo_li_button.append($photo_button);
+                $photo_ul.append($photo_li_label);
+                $photo_ul.append($photo_li_button);
+                $photo_li.append($photo_ul);
+                $ul.append($photo_li);
+
+                const results = await Ajax.get(this.getProcessUrl('member'), { member_id: member_id });
+
+                const data = {
+                    name: '이름',
+                    email: '이메일',
+                    password: '패스워드변경',
+                    nickname: '닉네임',
+                    cellphone: '휴대전화번호',
+                };
+
+                if (results.success === true) {
+                    Object.entries(results.data).forEach(([key, value]) => {
+                        if (data[key]) {
+                            const $li = Html.create('li', { 'data-role': `${key}` });
+                            const $innerUl = Html.create('ul');
+
+                            const $left = Html.create('li');
+                            const $left_text = Html.create('b', { class: 'require' }, data[key]);
+                            $left.append($left_text);
+                            $innerUl.append($left);
+
+                            const $right = Html.create('li');
+                            const $right_text = Html.create('input', {
+                                type: 'text',
+                                name: key,
+                                value: value,
+                            });
+                            $right.append($right_text);
+                            $innerUl.append($right);
+
+                            $li.append($innerUl);
+                            $ul.append($li);
+
+                            /**
+                             * 이메일 아래 열에 패스워드를 입력하기 위해서 기재했다.
+                             */
+                            if (key === 'email') {
+                                const $li = Html.create('li');
+                                const $password = Html.create('ul', { class: 'password' });
+
+                                const $text = Html.create('li');
+                                const $b = Html.create('b', null, '패스워드');
+                                $text.append($b);
+                                $password.append($text);
+
+                                const $button_li = Html.create('li');
+                                const $button = Html.create(
+                                    'button',
+                                    {
+                                        'data-role': 'password',
+                                        'data-action': 'password',
+                                        type: 'button',
+                                    },
+                                    '패스워드변경'
+                                );
+                                $button_li.append($button);
+                                $password.append($button_li);
+
+                                $button.on('click', async () => {
+                                    iModules.Modal.show(
+                                        '패스워드 변경',
+                                        `<form class="password"><input type="hidden"><input name="password" type="password" style="width: 100%; padding: 10px; border: 1px solid #9c9c9c; line-height: 18px;" placeholder="변경할 패스워드"><input name="password_confirm" type="password" style="width: 100%; margin-top: 10px;padding: 10px; border: 1px solid #9c9c9c; line-height: 18px;" placeholder="패스워드확인"></form>`,
+                                        [
+                                            {
+                                                text: '취소',
+                                                class: 'close',
+                                                handler: () => {
+                                                    iModules.Modal.close();
+                                                },
+                                            },
+                                            {
+                                                text: '확인',
+                                                class: 'confirm',
+                                                handler: async () => {
+                                                    this.updatePassword();
+                                                },
+                                            },
+                                        ]
+                                    );
+                                });
+
+                                $li.append($password);
+                                $ul.append($li);
+                            }
+                        }
+                    });
+                }
+
+                $form.append($ul);
+
+                const $buttonDiv = Html.create('div', { 'data-role': 'button' });
+                const $submitButton = Html.create('button', { type: 'submit' }, '확인');
+
+                $submitButton.on('click', async () => {
+                    this.updateUser(member_id);
+                });
+
+                $buttonDiv.append($submitButton);
+                $form.append($buttonDiv);
+
+                $update.append($form);
+                $container.append($update);
+                $profile.append($container);
+            }
+
+            /**
+             * 회원정보를 수정한다.
+             *
+             * @param {string} member_id - 멤버 고유값
+             */
+            async updateUser(member_id: string): Promise<void> {
+                const $form = Html.get('form', this.$dom);
+                const form = Form.get($form);
+                form.onSubmit(async () => {
+                    const results = await form.submit(this.getProcessUrl('member'), {
+                        member_id: member_id,
+                    });
+                    if (results.success == true) {
+                        iModules.Modal.show('확인', '회원정보가 성공적으로 수정되었습니다.', [
+                            {
+                                text: '확인',
+                                class: 'confirm',
+                                handler: () => {
+                                    iModules.Modal.close();
+                                    location.reload();
+                                },
+                            },
+                        ]);
+                    }
+                    if (results.success == false) {
+                        iModules.Modal.show(
+                            '문제가 발생하였습니다.',
+                            results.message ?? '요청을 처리하던 중 문제가 발생하였습니다.',
+                            [
+                                {
+                                    text: '확인',
+                                    class: 'confirm',
+                                    handler: () => {
+                                        iModules.Modal.close();
+                                    },
+                                },
+                            ]
+                        );
+                    }
+                });
+            }
+
+            /**
+             * 프로필사진을 수정한다.
+             */
+            async updatePhoto(): Promise<void> {
                 let cropper: Cropper | null = null;
 
                 /**
@@ -314,121 +439,44 @@ namespace modules {
                         ]
                     );
                 });
-
-                /**
-                 * Form 전송
-                 */
-                const $form = Html.get('form', this.$dom);
-                const form = Form.get($form);
-                form.onSubmit(async () => {
-                    const results = await form.submit(this.getProcessUrl('member'), {
-                        member_id: member_id,
-                    });
-                    if (results.success == true) {
-                        iModules.Modal.show('확인', '회원정보가 성공적으로 수정되었습니다.', [
-                            {
-                                text: '확인',
-                                class: 'confirm',
-                                handler: () => {
-                                    iModules.Modal.close();
-                                    location.reload();
-                                },
-                            },
-                        ]);
-                    }
-                    if (results.success == false) {
-                        iModules.Modal.show(
-                            '문제가 발생하였습니다.',
-                            results.message ?? '요청을 처리하던 중 문제가 발생하였습니다.',
-                            [
-                                {
-                                    text: '확인',
-                                    class: 'confirm',
-                                    handler: () => {
-                                        iModules.Modal.close();
-                                    },
-                                },
-                            ]
-                        );
-                    }
-                });
-            }
-
-            /**
-             * 비밀번호 모달창을 띄운다.
-             *
-             * @param {string} member_id 회원 고유값
-             */
-            showPassword(member_id: string): void {
-                const $button: any = Html.get('button[data-action="password"]').getEl();
-
-                $button.addEventListener('click', () => {
-                    iModules.Modal.show(
-                        '패스워드 변경',
-                        '<div><form><input name="new_password" type="password" style="width: 100%; padding: 10px; border: 1px solid #9c9c9c; line-height: 18px;" placeholder="변경할 패스워드"><input data-name="new_password_confirm" type="password" style="width: 100%; margin-top: 10px;padding: 10px; border: 1px solid #9c9c9c; line-height: 18px;" placeholder="패스워드확인"></form></div>',
-                        [
-                            {
-                                text: '취소',
-                                class: 'close',
-                                handler: () => {
-                                    iModules.Modal.close();
-                                },
-                            },
-                            {
-                                text: '확인',
-                                class: 'confirm',
-                                handler: () => {
-                                    this.updatePassword(member_id);
-                                },
-                            },
-                        ]
-                    );
-                });
             }
 
             /**
              * 비밀번호를 변경한다.
              */
-            updatePassword(member_id: string) {
-                const $form = Html.get('form', this.$dom);
+            async updatePassword(): Promise<void> {
+                const $form = Html.get('form.password');
                 const form = Form.get($form);
-                form.onSubmit(async () => {
-                    const results = await form.submit(this.getProcessUrl('member'), {
-                        member_id: member_id,
-                    });
-                    if (results.success == true) {
-                        iModules.Modal.show(
-                            '확인',
-                            '패스워드가 성공적으로 변경되었습니다.<br>다음 로그인시 부터 변경된 패스워드로 로그인이 가능합니다.',
-                            [
-                                {
-                                    text: '확인',
-                                    class: 'confirm',
-                                    handler: () => {
-                                        iModules.Modal.close();
-                                        location.reload();
-                                    },
+                const results = await form.submit(this.getProcessUrl('password'));
+                if (results.success == true) {
+                    iModules.Modal.show(
+                        '확인',
+                        '패스워드가 성공적으로 변경되었습니다.<br>다음 로그인시 부터 변경된 패스워드로 로그인이 가능합니다.',
+                        [
+                            {
+                                text: '확인',
+                                class: 'confirm',
+                                handler: () => {
+                                    iModules.Modal.close();
                                 },
-                            ]
-                        );
-                    }
-
-                    if (results.success == false) {
-                        iModules.Modal.show(
-                            '문제가 발생하였습니다.',
-                            results.message ?? '요청을 처리하던 중 문제가 발생하였습니다.',
-                            [
-                                {
-                                    text: '확인',
-                                    class: 'confirm',
-                                    handler: () => {
-                                        iModules.Modal.close();
-                                    },
+                            },
+                        ]
+                    );
+                } else {
+                    iModules.Modal.show(
+                        '문제가 발생하였습니다.',
+                        '요청을 처리하던 중 문제가 발생하였습니다.<br>다시 시도해주세요.',
+                        [
+                            {
+                                text: '확인',
+                                class: 'confirm',
+                                handler: () => {
+                                    iModules.Modal.close();
                                 },
-                            ]
-                        );
-                    }
-                });
+                            },
+                        ]
+                    );
+                }
             }
 
             /**
@@ -445,9 +493,6 @@ namespace modules {
     }
 }
 
-/**
- * Cropper Class 선언
- */
 declare class Cropper {
     constructor(
         image: HTMLImageElement,

--- a/templates/default/contexts/edit.html
+++ b/templates/default/contexts/edit.html
@@ -7,7 +7,7 @@
  * @file /modules/member/templates/default/contexts/edit.html
  * @author youlapark <youlapark@naddle.net>
  * @license MIT License
- * @modified 2024. 11. 8.
+ * @modified 2024. 11. 15.
  *
  * @var \modules\member\dtos\Member $member 회원정보
  */
@@ -15,7 +15,6 @@ if (defined('__IM__') == false) {
     exit();
 }
 ?>
-<!--
 <section data-role="edit">
     <div data-role="container">
         <form>
@@ -26,7 +25,7 @@ if (defined('__IM__') == false) {
             </div>
             <div data-role="input">
                 <?php Form::input('password', 'password')->placeholder('패스워드')->doLayout(); ?>
-                <input type="hidden" name="email" value="<?php echo $member->getEmail()?>">
+                <div data-role="message"></div>
             </div>
             <div data-role="button">
                 <button type="submit" data-role="button" class="confirm">확인</button>
@@ -34,56 +33,5 @@ if (defined('__IM__') == false) {
         </form>
     </div>
 </section>
--->
-<section data-role="profile" data-photo='<?php echo $photo ?>' data-user-id='<?php echo $member->getId(); ?>'>
-    <div data-role='container'>
-        <div data-role="update">
-            <h4>기본정보수정</h4>
-            <form>
-                <ul data-role="form">
-                    <li data-role="photo">
-                        <ul>
-                            <li><b >회원사진</b></li>
-                            <li><button style="background-image:linear-gradient(to bottom,
-                            rgba(0, 0, 0, 0) 60%,
-                            rgba(0, 0, 0, 0.7) 100%),url('<?php echo $photo?>')" type="button" data-action="photo"></button></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <ul>
-                            <li><b class="require">실명</b></li>
-                            <li><input type="text" name="name" value="<?php echo $member->getName()?>"></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <ul>
-                            <li><b class="require">이메일</b></li>
-                            <li><input type="text" name="email" value="<?php echo $member->getEmail()?>"></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <ul class="password">
-                            <li><b>패스워드</b></li>
-                            <li><button data-role="password" type="button" data-action="password">패스워드변경</button></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <ul>
-                            <li><b class="require">닉네임</b></li>
-                            <li><input type="text" name="nickname" value="<?php echo $member->getNickname()?>"></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <ul>
-                            <li><b class="require">휴대전화번호</b></li>
-                            <li><input type="text" name="cellphone" value="<?php echo $member->getCellphone()?>"></li>
-                        </ul>
-                    </li>
-                </ul>
-                <div data-role="button">
-                    <button type="submit">확인</button>
-                </div>
-            </form>
-        </div>
-    </div>
-</section>
+
+<section data-role="profile" data-photo='<?php echo $photo ?>' data-user-id='<?php echo $member->getId(); ?>'></section>

--- a/templates/default/styles/style.css
+++ b/templates/default/styles/style.css
@@ -6,7 +6,7 @@
  * @file /modules/member/templates/default/styles/style.css
  * @author youlapark <youlapark@naddle.net>
  * @license MIT License
- * @modified 2024. 11. 8.
+ * @modified 2024. 11. 15.
  */
 div[data-role='module'][data-module='member'][data-template='default'] {
 
@@ -177,13 +177,6 @@ div[data-role='module'][data-module='member'][data-template='default'] {
                         border-top: 1px solid var(--im-color-background-300);
                         line-height: 18px;
                         font-size: var(--im-font-size-h6);
-
-                        > input {
-                            width: 100%;
-                            padding: 10px;
-                            border: 1px solid var(--im-color-background-200);
-                            line-height: 18px;
-                        }
                     }
 
                     > div[data-role='button'] {


### PR DESCRIPTION
@Todo 로 지정되어진 부분 해결

# 1. API 추가 생성
- login.check.post.php : 로그인 회원의 유효성 체크
- password.post.php : 회원 패스워드 변경

# 2. Memter.ts 리팩토링
## (1) 회원 검증 분기 처리 해결
- init() 메서드 내에서 분기처리하지 않고, 회원의 유효성이 검증되었을 경우 정보수정 페이지가 뜨도록 수정

## (1) 메서드 분기
1. showAuthCheck()
- 목적 : 회원의 유효성 검사
- 실행 API : login.check.post.php

2. showProfile()
- 목적 : '기본정보수정' 페이지로 페이지를 변환한다.
- 변경사항 : 기존 Html에 입력했으나, 현재 Dom 에 직접 실음

3. updatePassword()
- 목적 : 비밀번호를 변경한다.
- 실행 API : password.post.php

4. updateUser(member_id)
- 목적 : 회원의 이름, 닉네임, 이메일, 휴대전화번호를 수정한다.